### PR TITLE
Remove AI fields from device/pool listings

### DIFF
--- a/backend/listar_dispositivos.php
+++ b/backend/listar_dispositivos.php
@@ -36,11 +36,7 @@ try {
                 d.di05_nome, d.di05_tipo, d.di05_status,
                 d.di06_nome, d.di06_tipo, d.di06_status,
                 d.di07_nome, d.di07_tipo, d.di07_status,
-                d.di08_nome, d.di08_tipo, d.di08_status,
-                d.ai01_nome, d.ai01_tipo,
-                d.ai02_nome, d.ai02_tipo,
-                d.ai03_nome, d.ai03_tipo,
-                d.ai04_nome, d.ai04_tipo
+                d.di08_nome, d.di08_tipo, d.di08_status
             FROM dispositivos d
             INNER JOIN piscinas p ON d.piscina_id = p.id
         ";
@@ -81,11 +77,7 @@ try {
                 d.di05_nome, d.di05_tipo, d.di05_status,
                 d.di06_nome, d.di06_tipo, d.di06_status,
                 d.di07_nome, d.di07_tipo, d.di07_status,
-                d.di08_nome, d.di08_tipo, d.di08_status,
-                d.ai01_nome, d.ai01_tipo,
-                d.ai02_nome, d.ai02_tipo,
-                d.ai03_nome, d.ai03_tipo,
-                d.ai04_nome, d.ai04_tipo
+                d.di08_nome, d.di08_tipo, d.di08_status
             FROM dispositivos d
         ";
 

--- a/backend/listar_piscinas.php
+++ b/backend/listar_piscinas.php
@@ -42,11 +42,7 @@ try {
             d.di05_nome, d.di05_tipo, d.di05_status,
             d.di06_nome, d.di06_tipo, d.di06_status,
             d.di07_nome, d.di07_tipo, d.di07_status,
-            d.di08_nome, d.di08_tipo, d.di08_status,
-            d.ai01_nome, d.ai01_escala,
-            d.ai02_nome, d.ai02_escala,
-            d.ai03_nome, d.ai03_escala,
-            d.ai04_nome, d.ai04_escala
+            d.di08_nome, d.di08_tipo, d.di08_status
 
         FROM 
             piscinas p


### PR DESCRIPTION
## Summary
- strip unused analog input names from `listar_dispositivos.php` and `listar_piscinas.php`

## Testing
- `php -l backend/listar_dispositivos.php` *(fails: php not installed)*
- `php -l backend/listar_piscinas.php` *(fails: php not installed)*


------
https://chatgpt.com/codex/tasks/task_e_685e953d580483279711b27f23a11f48