### PR TITLE
Add admin listing capability

### DIFF
--- a/backend/listar_locais.php
+++ b/backend/listar_locais.php
@@ -9,9 +9,15 @@ if (!isset($_SESSION['UsuarioID'])) {
 }
 
 $usuarioID = $_SESSION['UsuarioID'];
+$isAdmin = $_SESSION['UsuarioAdmin'] ?? 0;
+$query = $isAdmin
+    ? "SELECT id, nome FROM enderecos"
+    : "SELECT id, nome FROM enderecos WHERE usuario_id = :usuarioID";
 
-$stmt = $pdo->prepare("SELECT id, nome FROM enderecos WHERE usuario_id = :usuarioID");
-$stmt->bindParam(':usuarioID', $usuarioID);
+$stmt = $pdo->prepare($query);
+if (!$isAdmin) {
+    $stmt->bindParam(':usuarioID', $usuarioID);
+}
 $stmt->execute();
 
 $locais = $stmt->fetchAll(PDO::FETCH_ASSOC);

--- a/backend/listar_piscinas_dispositivos.php
+++ b/backend/listar_piscinas_dispositivos.php
@@ -9,9 +9,16 @@ if (!isset($_SESSION['UsuarioID'])) {
 }
 
 $usuarioID = $_SESSION['UsuarioID'];
+$isAdmin   = $_SESSION['UsuarioAdmin'] ?? 0;
 
-$stmt = $pdo->prepare("SELECT id, nome FROM piscinas WHERE usuario_id = :usuarioID");
-$stmt->bindParam(':usuarioID', $usuarioID);
+$query = $isAdmin
+    ? "SELECT id, nome FROM piscinas"
+    : "SELECT id, nome FROM piscinas WHERE usuario_id = :usuarioID";
+
+$stmt = $pdo->prepare($query);
+if (!$isAdmin) {
+    $stmt->bindParam(':usuarioID', $usuarioID);
+}
 $stmt->execute();
 
 $locais = $stmt->fetchAll(PDO::FETCH_ASSOC);


### PR DESCRIPTION
## Summary
- allow admin to access all addresses in listar_locais.php
- allow admin to access all pools in listar_piscinas_dispositivos.php

## Testing
- `php -l backend/listar_locais.php`
- `php -l backend/listar_piscinas_dispositivos.php`
- `php -l backend/listar_enderecos.php`
- `php -l backend/listar_piscinas.php`
- `php -l backend/listar_dispositivos.php`


------
https://chatgpt.com/codex/tasks/task_e_685ea9e6ac8883278d7af74613b4f45b