### PR TITLE
Add collapsible device sections to pool cards

### DIFF
--- a/app/assets/css/style.css
+++ b/app/assets/css/style.css
@@ -478,3 +478,22 @@ body.dark-theme .digital-card .digital-icon i[style*="#888"] { color: #777 !impo
   }
 }
 
+/* ---------- Seções de dispositivos nos cards das piscinas ---------- */
+.device-section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    cursor: pointer;
+    margin-top: 10px;
+}
+.device-section-header button {
+    background: none;
+    border: none;
+    padding: 0;
+    color: inherit;
+}
+.device-section-body {
+    margin-top: 8px;
+}
+
+


### PR DESCRIPTION
## Summary
- organize devices inside pool cards by type
- toggle device sections with a collapse button
- style new device sections

## Testing
- `node --check app/assets/js/listings.js`

------
https://chatgpt.com/codex/tasks/task_e_685ed289570883278dd3818573216d22