### PR TITLE
Adjust device header style for dark mode

### DIFF
--- a/app/assets/css/style.css
+++ b/app/assets/css/style.css
@@ -478,3 +478,32 @@ body.dark-theme .digital-card .digital-icon i[style*="#888"] { color: #777 !impo
   }
 }
 
+/* ---------- Seções de dispositivos nos cards das piscinas ---------- */
+.device-section-header {
+    position: relative;
+    cursor: pointer;
+    margin-top: 10px;
+    padding: 6px 8px 6px 32px;
+    border-radius: 4px;
+    font-weight: bold;
+}
+body.light-theme .device-section-header { background: #f1f3f5; }
+body.dark-theme .device-section-header { background: #252930; color: #f6f8fa; }
+.device-section-header button {
+    position: absolute;
+    top: 50%;
+    left: 8px;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    padding: 0;
+    color: inherit;
+}
+.device-section-header button.collapsed i {
+    transform: rotate(-90deg);
+}
+.device-section-body {
+    margin-top: 6px;
+}
+
+


### PR DESCRIPTION
## Summary
- tweak device section header colors to work with both light and dark themes

## Testing
- `node --check app/assets/js/listings.js`


------
https://chatgpt.com/codex/tasks/task_e_685ed289570883278dd3818573216d22