### PR TITLE
Adjust device header style for dark mode

### DIFF
--- a/app/assets/css/style.css
+++ b/app/assets/css/style.css
@@ -478,3 +478,32 @@ body.dark-theme .digital-card .digital-icon i[style*="#888"] { color: #777 !impo
   }
 }
 
+/* ---------- Seções de dispositivos nos cards das piscinas ---------- */
+.device-section-header {
+    position: relative;
+    cursor: pointer;
+    margin-top: 10px;
+    padding: 6px 8px 6px 32px;
+    border-radius: 4px;
+    font-weight: bold;
+}
+body.light-theme .device-section-header { background: #f1f3f5; }
+body.dark-theme .device-section-header { background: #252930; color: #f6f8fa; }
+.device-section-header button {
+    position: absolute;
+    top: 50%;
+    left: 8px;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    padding: 0;
+    color: inherit;
+}
+.device-section-header button.collapsed i {
+    transform: rotate(-90deg);
+}
+.device-section-body {
+    margin-top: 6px;
+}
+
+

--- a/backend/listar_piscinas.php
+++ b/backend/listar_piscinas.php
@@ -16,37 +16,16 @@ $enderecoID = isset($_GET['endereco_id']) ? intval($_GET['endereco_id']) : null;
 
 try {
     $sql = "
-        SELECT 
+        SELECT
             p.id AS piscina_id,
             p.nome AS piscina_nome,
             e.nome AS endereco_nome,
-            p.data_hora,
-            d.ph AS ph,
-            d.orp AS orp,
-            d.temperatura AS temperatura,
-            d.setpoint,
-            d.digipot,
-            d.tensao,
-            d.corrente,
-            d.temp_habilitada,
-            d.data_hora AS data_hora_automatic,
+            p.data_hora
 
-            -- Entradas digitais
-            d.di01_nome, d.di01_tipo, d.di01_status,
-            d.di02_nome, d.di02_tipo, d.di02_status,
-            d.di03_nome, d.di03_tipo, d.di03_status,
-            d.di04_nome, d.di04_tipo, d.di04_status,
-            d.di05_nome, d.di05_tipo, d.di05_status,
-            d.di06_nome, d.di06_tipo, d.di06_status,
-            d.di07_nome, d.di07_tipo, d.di07_status,
-            d.di08_nome, d.di08_tipo, d.di08_status
-
-        FROM 
+        FROM
             piscinas p
-        JOIN 
+        JOIN
             enderecos e ON p.endereco_id = e.id
-        LEFT JOIN 
-            dispositivos d ON p.id = d.piscina_id
         WHERE 1 = 1
     ";
 


### PR DESCRIPTION
## Summary
- tweak device section header colors to work with both light and dark themes
- prevent duplicate pools by removing the device join from `listar_piscinas.php`

## Testing
- `node --check app/assets/js/listings.js`


------
https://chatgpt.com/codex/tasks/task_e_685ed289570883278dd3818573216d22