### PR TITLE
Fix listar_dispositivos block

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # 📝 CHANGELOG – PoolCloud
+## 📅 [2025-07-04] – Correção na listagem de dispositivos
+- Ajustado fechamento de bloco em `listar_dispositivos.php` para evitar erro 500.
+
 
 Histórico de mudanças e atualizações no sistema PoolCloud.
 ## 📅 [2025-07-01] – Ajuste de margens nos cards de piscinas e dispositivos

--- a/backend/listar_dispositivos.php
+++ b/backend/listar_dispositivos.php
@@ -97,6 +97,8 @@ if (!$is_admin) {
         $stmt->bindParam(':usuario_id', $usuario_id, PDO::PARAM_INT);
     }
 
+    }
+
     $stmt->execute();
     $resultados = $stmt->fetchAll(PDO::FETCH_ASSOC);
 


### PR DESCRIPTION
## Summary
- close missing conditional block in `listar_dispositivos.php`
- note fix in changelog

## Testing
- `python3 - <<'EOF'
stack=[]
for i,line in enumerate(open('backend/listar_dispositivos.php'),1):
    for ch in line:
        if ch=='{':
            stack.append(i)
        elif ch=='}':
            if stack:
                stack.pop()
print('stack', stack)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_686826b35074832784db24c01ee57309