### PR TITLE
Fix listar_dispositivos logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # 📝 CHANGELOG – PoolCloud
+## 📅 [2025-07-04] – Correção na listagem de dispositivos
+- Ajustado fechamento de bloco em `listar_dispositivos.php` para evitar erro 500.
+- Corrigida montagem da consulta em `listar_dispositivos.php` quando não há `piscina_id`.
+
 
 Histórico de mudanças e atualizações no sistema PoolCloud.
 ## 📅 [2025-07-01] – Ajuste de margens nos cards de piscinas e dispositivos

--- a/backend/listar_dispositivos.php
+++ b/backend/listar_dispositivos.php
@@ -52,11 +52,11 @@ try {
         }
 
         $stmt = $pdo->prepare($sql);
-$stmt->bindParam(':piscina_id', $piscina_id, PDO::PARAM_INT);
-if (!$is_admin) {
-    $stmt->bindParam(':usuario_id', $usuario_id, PDO::PARAM_INT);
-}
- else {
+        $stmt->bindParam(':piscina_id', $piscina_id, PDO::PARAM_INT);
+        if (!$is_admin) {
+            $stmt->bindParam(':usuario_id', $usuario_id, PDO::PARAM_INT);
+        }
+    } else {
         $sql = "
             SELECT
                 d.id AS dispositivo_id,
@@ -94,7 +94,9 @@ if (!$is_admin) {
         }
 
         $stmt = $pdo->prepare($sql);
-        $stmt->bindParam(':usuario_id', $usuario_id, PDO::PARAM_INT);
+        if (!$is_admin) {
+            $stmt->bindParam(':usuario_id', $usuario_id, PDO::PARAM_INT);
+        }
     }
 
     $stmt->execute();


### PR DESCRIPTION
## Summary
- fix query logic when `piscina_id` is missing in `listar_dispositivos.php`
- document device listing fix

## Testing
- `python3 - <<'EOF'
stack=[]
for i,line in enumerate(open('backend/listar_dispositivos.php'),1):
    for ch in line:
        if ch=='{':
            stack.append((i,ch))
        elif ch=='}':
            if stack:
                stack.pop()
            else:
                print('unmatched } on line', i)
print('stack', stack)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_686826b35074832784db24c01ee57309