### PR TITLE
Fix mobile card column padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # 📝 CHANGELOG – PoolCloud
+## 📅 [2025-07-06] – Ajuste de padding nos cards
+- Ajuste no padding das colunas dos cards no mobile para evitar vazamento dos quadradinhos.
 ## 📅 [2025-07-05] – Compartilhamentos integrados
 - Nova seção "Compartilhamentos" exibida na página principal.
 - Inclusão do script `compartilhamentos.js` em todas as páginas.

--- a/app/assets/css/style.css
+++ b/app/assets/css/style.css
@@ -287,6 +287,12 @@ body.dark-theme .digital-card .digital-icon i[style*="#888"] { color: #777 !impo
     margin-left: 0;
     margin-right: 0;
 }
+.parametros-row > .col-4,
+.parametros-row > .col-6,
+.parametros-row > .col-12 {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+}
 .parametros-row .col-4,
 .parametros-row .col-6,
 .pool-card .parametros-row > .col-6 {


### PR DESCRIPTION
## Summary
- remove horizontal padding from `.parametros-row` children
- document padding fix in changelog

## Testing
- `php -l index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868304040c0832783af38b4656577e3