### PR TITLE
Fix mobile swiper alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # 📝 CHANGELOG – PoolCloud
+## 📅 [2025-07-08] – Correção de alinhamento vertical
+- `.swiper-slide` agora centraliza o conteúdo verticalmente no layout mobile.
 ## 📅 [2025-07-07] – Correção de navegação nas piscinas
 - Swiper das piscinas agora atualiza a barra de nome ao trocar de slide.
 - Configuração `slidesPerGroup` ajustada para 1 para navegação mais fluida.

--- a/app/assets/css/style.css
+++ b/app/assets/css/style.css
@@ -330,7 +330,7 @@ body.dark-theme .digital-card .digital-icon i[style*="#888"] { color: #777 !impo
         padding-left: 0 !important; padding-right: 0 !important;
     }
     .swiper-slide {
-        display: flex; flex-direction: column; align-items: center; justify-content: flex-start;
+        display: flex; flex-direction: column; align-items: center; justify-content: center;
         min-height: 360px; background: none; padding: 0; margin: 0 !important;
     }
     .pool-card {


### PR DESCRIPTION
## Summary
- center content vertically in mobile `.swiper-slide`
- document alignment fix in changelog

## Testing
- `php -l index.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6868331f80148327958f8be457a2d9d9